### PR TITLE
4.0.0 Filament 4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to `filament-page-builder` will be documented in this file.
 
 
+## 4.0.0 Filament 4 compatible
+- Upgrade to Filament v4 (`Filament\Schemas\*`, `HasSchemas`, `getActiveSchemaLocale()`)
+- Replace `filament/spatie-laravel-translatable-plugin` with `lara-zeus/spatie-translatable`
+- `BlockEditor` now uses the v4 Builder state pattern via `getItems()` + `Schema`
+- `BlockEditorBlock::getChildComponents()` moved to `getDefaultChildComponents()`
+- Preview mode uses `live(debounce: 500)` instead of deprecated `reactive()`/`debounce()`
+- Requires PHP ^8.2, Laravel ^11.28 / ^12.0
+
 ## 3.0.9 Laravel 12 compatible
 
 ## 3.0.8 Laravel 11 compatible

--- a/composer.json
+++ b/composer.json
@@ -24,22 +24,21 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^3.0.75",
-        "filament/spatie-laravel-translatable-plugin": "^3.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
-        "spatie/laravel-package-tools": "^1.13.5",
-        "wire-elements/modal": "^2.0"
+        "filament/filament": "^4.0",
+        "illuminate/contracts": "^11.28|^12.0",
+        "lara-zeus/spatie-translatable": "^1.0",
+        "spatie/laravel-package-tools": "^1.13.5"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0",
-        "pestphp/pest": "^1.23",
+        "larastan/larastan": "^3.0",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0|^10.0",
+        "pestphp/pest": "^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^11.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Trait Sevendays\\FilamentPageBuilder\\Models\\Traits\\HasBlocks is used zero times and is not analysed\.$#'
+            identifier: trait.unused
+            count: 1
+            path: src/Models/Traits/HasBlocks.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,5 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
+    treatPhpDocTypesAsCertain: false
 

--- a/resources/views/block-editor.blade.php
+++ b/resources/views/block-editor.blade.php
@@ -1,199 +1,231 @@
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
-    @php
-        $containers = $getChildComponentContainers();
-        $blockPickerColumns = $getBlockPickerColumns();
-        $blockPickerWidth = $getBlockPickerWidth();
-        $blocks = $getBlocks();
+@php
+    use Filament\Actions\Action;
 
-        $addAction = $getAction($getAddActionName());
-        $addBetweenAction = $getAction($getAddBetweenActionName());
-        $cloneAction = $getAction($getCloneActionName());
-        $collapseAllAction = $getAction($getCollapseAllActionName());
-        $expandAllAction = $getAction($getExpandAllActionName());
-        $deleteAction = $getAction($getDeleteActionName());
-        $moveDownAction = $getAction($getMoveDownActionName());
-        $moveUpAction = $getAction($getMoveUpActionName());
-        $reorderAction = $getAction($getReorderActionName());
+    $fieldWrapperView = $getFieldWrapperView();
+    $items = $getItems();
+    $blockPickerBlocks = $getBlockPickerBlocks();
+    $blockPickerColumns = $getBlockPickerColumns();
+    $blockPickerWidth = $getBlockPickerWidth();
 
-        $isAddable = $isAddable();
-        $isCloneable = $isCloneable();
-        $isCollapsible = $isCollapsible();
-        $isDeletable = $isDeletable();
-        $isReorderableWithButtons = $isReorderableWithButtons();
-        $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
+    $addAction = $getAction($getAddActionName());
+    $addActionAlignment = $getAddActionAlignment();
+    $addBetweenAction = $getAction($getAddBetweenActionName());
+    $cloneAction = $getAction($getCloneActionName());
+    $collapseAllAction = $getAction($getCollapseAllActionName());
+    $expandAllAction = $getAction($getExpandAllActionName());
+    $deleteAction = $getAction($getDeleteActionName());
+    $moveDownAction = $getAction($getMoveDownActionName());
+    $moveUpAction = $getAction($getMoveUpActionName());
+    $reorderAction = $getAction($getReorderActionName());
+    $extraItemActions = $getExtraItemActions();
 
-        $statePath = $getStatePath();
-    @endphp
+    $isAddable = $isAddable();
+    $isCloneable = $isCloneable();
+    $isCollapsible = $isCollapsible();
+    $isDeletable = $isDeletable();
+    $isReorderableWithButtons = $isReorderableWithButtons();
+    $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
 
-    <div x-data="{ showModal: false }"
+    $collapseAllActionIsVisible = $isCollapsible && $collapseAllAction->isVisible();
+    $expandAllActionIsVisible = $isCollapsible && $expandAllAction->isVisible();
+
+    $key = $getKey();
+    $statePath = $getStatePath();
+
+    $blockLabelHeadingTag = $getHeadingTag();
+    $isBlockLabelTruncated = $isBlockLabelTruncated();
+    $labelBetweenItems = $getLabelBetweenItems();
+
+    $previewEnabled = config('filament-page-builder.enablePreview');
+@endphp
+
+<x-dynamic-component :component="$fieldWrapperView" :field="$field">
+    <div
+        x-data="{ showModal: false }"
         {{
             $attributes
                 ->merge($getExtraAttributes(), escape: false)
-                ->class(['fi-fo-builder grid gap-y-4'])
+                ->class([
+                    'fi-fo-builder',
+                    'fi-collapsible' => $isCollapsible,
+                ])
         }}
     >
-        <div x-bind:class="{ 'inset-0 fixed z-30 bg-black/80  h-screen w-screen overscroll-contain gap-4 flex': showModal }">
-            <div x-bind:class="{ 'p-4 m-6 bg-gray-50 w-full grow flex md:flex-rows relative rounded-lg': showModal }" @click.outside="showModal=false">
-                <div x-bind:class="{ 'basis-1/3 p-4 overflow-y-auto flex flex-col w-full ': showModal }">
+        <div x-bind:class="{ 'inset-0 fixed z-30 bg-black/80 h-screen w-screen overscroll-contain gap-4 flex': showModal }">
+            <div x-bind:class="{ 'p-4 m-6 bg-gray-50 dark:bg-gray-900 w-full grow flex md:flex-rows relative rounded-lg': showModal }" @click.outside="showModal = false">
+                <div x-bind:class="{ 'basis-1/3 p-4 overflow-y-auto flex flex-col w-full': showModal }">
                     <div class="flex flex-row justify-between mb-4 items-center">
-                        @if ($isCollapsible && ($collapseAllAction->isVisible() || $expandAllAction->isVisible()))
+                        @if ($collapseAllActionIsVisible || $expandAllActionIsVisible)
                             <div
                                 @class([
-                                    'flex gap-x-3',
-                                    'hidden' => count($containers) < 2,
+                                    'fi-fo-builder-actions flex gap-x-3',
+                                    'fi-hidden hidden' => count($items) < 2,
                                 ])
                             >
-                                @if ($collapseAllAction->isVisible())
-                                    <span
-                                        x-on:click="$dispatch('builder-collapse', '{{ $statePath }}')"
-                                    >
+                                @if ($collapseAllActionIsVisible)
+                                    <span x-on:click="$dispatch('builder-collapse', '{{ $statePath }}')">
                                         {{ $collapseAllAction }}
                                     </span>
                                 @endif
 
-                                @if ($expandAllAction->isVisible())
-                                    <span
-                                        x-on:click="$dispatch('builder-expand', '{{ $statePath }}')"
-                                    >
+                                @if ($expandAllActionIsVisible)
+                                    <span x-on:click="$dispatch('builder-expand', '{{ $statePath }}')">
                                         {{ $expandAllAction }}
                                     </span>
                                 @endif
                             </div>
                         @endif
-                        @if(config('filament-page-builder.enablePreview'))
+
+                        @if ($previewEnabled)
                             <div>
-                                <x-filament::button wire:key="open-visual-builder" x-on:click="showModal = true"
-                                                    x-show="showModal === false">Visual
-                                    builder
+                                <x-filament::button wire:key="open-visual-builder" x-on:click="showModal = true" x-show="showModal === false">
+                                    Visual builder
                                 </x-filament::button>
                             </div>
                         @endif
                     </div>
+
                     <div class="grid gap-y-4">
-                        @if (count($containers))
+                        @if (count($items))
                             <ul
                                 x-sortable
-                                wire:end.stop="{{ 'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })' }}"
-                                class="space-y-4"
+                                data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
+                                x-on:end.stop="
+                                    $wire.mountAction(
+                                        'reorder',
+                                        { items: $event.target.sortable.toArray() },
+                                        { schemaComponent: '{{ $key }}' },
+                                    )
+                                "
+                                class="fi-fo-builder-items space-y-4"
                             >
                                 @php
                                     $hasBlockLabels = $hasBlockLabels();
+                                    $hasBlockIcons = $hasBlockIcons();
                                     $hasBlockNumbers = $hasBlockNumbers();
                                 @endphp
 
-                                @foreach ($containers as $uuid => $item)
+                                @foreach ($items as $itemKey => $item)
+                                    @php
+                                        $visibleExtraItemActions = array_filter(
+                                            $extraItemActions,
+                                            fn (Action $action): bool => $action(['item' => $itemKey])->isVisible(),
+                                        );
+                                        $cloneActionForItem = $cloneAction(['item' => $itemKey]);
+                                        $cloneActionIsVisible = $isCloneable && $cloneActionForItem->isVisible();
+                                        $deleteActionForItem = $deleteAction(['item' => $itemKey]);
+                                        $deleteActionIsVisible = $isDeletable && $deleteActionForItem->isVisible();
+                                        $moveDownActionForItem = $moveDownAction(['item' => $itemKey])->disabled($loop->last);
+                                        $moveDownActionIsVisible = $isReorderableWithButtons && $moveDownActionForItem->isVisible();
+                                        $moveUpActionForItem = $moveUpAction(['item' => $itemKey])->disabled($loop->first);
+                                        $moveUpActionIsVisible = $isReorderableWithButtons && $moveUpActionForItem->isVisible();
+                                        $reorderActionIsVisible = $isReorderableWithDragAndDrop && $reorderAction->isVisible();
+                                        $hasItemHeader = ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible || $hasBlockIcons || $hasBlockLabels || $cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions);
+                                    @endphp
+
                                     <li
-                                        wire:key="{{ $this->getId() }}.{{ $item->getStatePath() }}.{{ $field::class }}.item"
-                                        x-data="{
-                                            isCollapsed: @js($isCollapsed($item)),
-                                        }"
+                                        wire:ignore.self
+                                        wire:key="{{ $item->getLivewireKey() }}.item"
+                                        x-data="{ isCollapsed: @js($isCollapsed($item)) }"
                                         x-on:builder-expand.window="$event.detail === '{{ $statePath }}' && (isCollapsed = false)"
                                         x-on:builder-collapse.window="$event.detail === '{{ $statePath }}' && (isCollapsed = true)"
-                                        x-on:expand-concealing-component.window="
-                                            $nextTick(() => {
-                                                error = $el.querySelector('[data-validation-error]')
-
-                                                if (! error) {
-                                                    return
-                                                }
-
-                                                isCollapsed = false
-
-                                                if (document.body.querySelector('[data-validation-error]') !== error) {
-                                                    return
-                                                }
-
-                                                setTimeout(
-                                                    () =>
-                                                        $el.scrollIntoView({
-                                                            behavior: 'smooth',
-                                                            block: 'start',
-                                                            inline: 'start',
-                                                        }),
-                                                    200,
-                                                )
-                                            })
-                                        "
-                                        x-sortable-item="{{ $uuid }}"
-                                        class="fi-fo-builder-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10"
+                                        x-on:expand="isCollapsed = false"
+                                        x-sortable-item="{{ $itemKey }}"
+                                        {{
+                                            $item->getParentComponent()->getExtraAttributeBag()
+                                                ->class([
+                                                    'fi-fo-builder-item rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10',
+                                                    'fi-fo-builder-item-has-header' => $hasItemHeader,
+                                                ])
+                                        }}
                                         x-bind:class="{ 'fi-collapsed overflow-hidden': isCollapsed }"
                                     >
-                                        @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons || $hasBlockLabels || $isCloneable || $isDeletable || $isCollapsible)
+                                        @if ($hasItemHeader)
                                             <div
+                                                @if ($isCollapsible)
+                                                    x-on:click.stop="isCollapsed = !isCollapsed"
+                                                @endif
                                                 class="fi-fo-builder-item-header flex items-center gap-x-3 overflow-hidden px-4 py-2"
                                             >
-                                                @if ($isReorderableWithDragAndDrop || $isReorderableWithButtons)
-                                                    <ul class="-ms-1.5 flex">
-                                                        @if ($isReorderableWithDragAndDrop)
-                                                            <li x-sortable-handle>
-                                                                {{ $reorderAction }}
+                                                @if ($reorderActionIsVisible || $moveUpActionIsVisible || $moveDownActionIsVisible)
+                                                    <ul class="fi-fo-builder-item-header-start-actions -ms-1.5 flex">
+                                                        @if ($reorderActionIsVisible)
+                                                            <li x-on:click.stop>
+                                                                {{ $reorderAction->extraAttributes(['x-sortable-handle' => true], merge: true) }}
                                                             </li>
                                                         @endif
 
-                                                        @if ($isReorderableWithButtons)
-                                                            <li
-                                                                class="flex items-center justify-center"
-                                                            >
-                                                                {{ $moveUpAction(['item' => $uuid])->disabled($loop->first) }}
+                                                        @if ($moveUpActionIsVisible || $moveDownActionIsVisible)
+                                                            <li x-on:click.stop class="flex items-center justify-center">
+                                                                {{ $moveUpActionForItem }}
                                                             </li>
 
-                                                            <li
-                                                                class="flex items-center justify-center"
-                                                            >
-                                                                {{ $moveDownAction(['item' => $uuid])->disabled($loop->last) }}
+                                                            <li x-on:click.stop class="flex items-center justify-center">
+                                                                {{ $moveDownActionForItem }}
                                                             </li>
                                                         @endif
                                                     </ul>
                                                 @endif
 
+                                                @php
+                                                    $blockIcon = $item->getParentComponent()->getIcon();
+                                                @endphp
+
+                                                @if ($hasBlockIcons && filled($blockIcon))
+                                                    {{ \Filament\Support\generate_icon_html($blockIcon, attributes: (new \Illuminate\View\ComponentAttributeBag)->class(['fi-fo-builder-item-header-icon'])) }}
+                                                @endif
+
                                                 @if ($hasBlockLabels)
-                                                    <h4
-                                                        @if ($isCollapsible)
-                                                            x-on:click.stop="isCollapsed = !isCollapsed"
-                                                        @endif
+                                                    <{{ $blockLabelHeadingTag }}
                                                         @class([
-                                                            'text-sm font-medium text-gray-950 dark:text-white',
-                                                            'truncate' => $isBlockLabelTruncated(),
+                                                            'fi-fo-builder-item-header-label text-sm font-medium text-gray-950 dark:text-white',
+                                                            'fi-truncated truncate' => $isBlockLabelTruncated,
                                                             'cursor-pointer select-none' => $isCollapsible,
                                                         ])
                                                     >
-                                                        {{ $item->getParentComponent()->getLabel($item->getRawState(), $uuid) }}
+                                                        {{ $item->getParentComponent()->getLabel($item->getRawState(), $itemKey, $loop->index) }}
 
                                                         @if ($hasBlockNumbers)
                                                             {{ $loop->iteration }}
                                                         @endif
-                                                    </h4>
+                                                    </{{ $blockLabelHeadingTag }}>
                                                 @endif
 
-                                                @if ($isCloneable || $isDeletable || $isCollapsible)
-                                                    <ul class="-me-1.5 ms-auto flex">
-                                                        @if ($isCloneable)
-                                                            <li>
-                                                                {{ $cloneAction(['item' => $uuid]) }}
+                                                @if ($cloneActionIsVisible || $deleteActionIsVisible || $isCollapsible || $visibleExtraItemActions)
+                                                    <ul class="fi-fo-builder-item-header-end-actions -me-1.5 ms-auto flex">
+                                                        @foreach ($visibleExtraItemActions as $extraItemAction)
+                                                            <li x-on:click.stop>
+                                                                {{ $extraItemAction(['item' => $itemKey]) }}
+                                                            </li>
+                                                        @endforeach
+
+                                                        @if ($cloneActionIsVisible)
+                                                            <li x-on:click.stop>
+                                                                {{ $cloneActionForItem }}
                                                             </li>
                                                         @endif
 
-                                                        @if ($isDeletable)
-                                                            <li>
-                                                                {{ $deleteAction(['item' => $uuid]) }}
+                                                        @if ($deleteActionIsVisible)
+                                                            <li x-on:click.stop>
+                                                                {{ $deleteActionForItem }}
                                                             </li>
                                                         @endif
 
                                                         @if ($isCollapsible)
                                                             <li
-                                                                class="relative transition"
+                                                                class="fi-fo-builder-item-header-collapsible-actions relative transition"
                                                                 x-on:click.stop="isCollapsed = !isCollapsed"
                                                                 x-bind:class="{ '-rotate-180': isCollapsed }"
                                                             >
                                                                 <div
-                                                                    class="transition"
+                                                                    class="fi-fo-builder-item-header-collapse-action transition"
                                                                     x-bind:class="{ 'opacity-0 pointer-events-none': isCollapsed }"
                                                                 >
                                                                     {{ $getAction('collapse') }}
                                                                 </div>
 
                                                                 <div
-                                                                    class="absolute inset-0 rotate-180 transition"
+                                                                    class="fi-fo-builder-item-header-expand-action absolute inset-0 rotate-180 transition"
                                                                     x-bind:class="{ 'opacity-0 pointer-events-none': ! isCollapsed }"
                                                                 >
                                                                     {{ $getAction('expand') }}
@@ -214,38 +246,30 @@
                                     </li>
 
                                     @if (! $loop->last)
-                                        @if ($isAddable && $addBetweenAction->isVisible())
-                                            <li class="relative -top-2 !mt-0 h-0">
-                                                <div
-                                                    class="flex w-full justify-center opacity-0 transition duration-75 hover:opacity-100"
-                                                >
-                                                    <div
-                                                        class="fi-fo-builder-block-picker-ctn rounded-lg bg-white dark:bg-gray-900"
-                                                    >
+                                        @if ($isAddable && $addBetweenAction(['afterItem' => $itemKey])->isVisible())
+                                            <li class="fi-fo-builder-add-between-items-ctn relative -top-2 !mt-0 h-0">
+                                                <div class="fi-fo-builder-add-between-items flex w-full justify-center opacity-0 transition duration-75 hover:opacity-100">
+                                                    <div class="fi-fo-builder-block-picker-ctn rounded-lg bg-white dark:bg-gray-900">
                                                         <x-filament-forms::builder.block-picker
                                                             :action="$addBetweenAction"
-                                                            :after-item="$uuid"
+                                                            :after-item="$itemKey"
                                                             :columns="$blockPickerColumns"
-                                                            :blocks="$blocks"
-                                                            :state-path="$statePath"
+                                                            :blocks="$blockPickerBlocks"
+                                                            :key="$key"
                                                             :width="$blockPickerWidth"
                                                         >
                                                             <x-slot name="trigger">
-                                                                {{ $addBetweenAction }}
+                                                                {{ $addBetweenAction(['afterItem' => $itemKey]) }}
                                                             </x-slot>
                                                         </x-filament-forms::builder.block-picker>
                                                     </div>
                                                 </div>
                                             </li>
-                                        @elseif (filled($labelBetweenItems = $getLabelBetweenItems()))
-                                            <li
-                                                class="relative border-t border-gray-200 dark:border-white/10"
-                                            >
-                                <span
-                                    class="absolute -top-3 left-3 bg-white px-1 text-sm font-medium dark:bg-gray-900"
-                                >
-                                    {{ $labelBetweenItems }}
-                                </span>
+                                        @elseif (filled($labelBetweenItems))
+                                            <li class="fi-fo-builder-label-between-items-ctn relative border-t border-gray-200 dark:border-white/10">
+                                                <span class="fi-fo-builder-label-between-items absolute -top-3 left-3 bg-white px-1 text-sm font-medium dark:bg-gray-900">
+                                                    {{ $labelBetweenItems }}
+                                                </span>
                                             </li>
                                         @endif
                                     @endif
@@ -253,12 +277,13 @@
                             </ul>
                         @endif
 
-                        @if ($isAddable)
+                        @if ($isAddable && $addAction->isVisible())
                             <x-filament-forms::builder.block-picker
                                 :action="$addAction"
-                                :blocks="$blocks"
+                                :action-alignment="$addActionAlignment"
+                                :blocks="$blockPickerBlocks"
                                 :columns="$blockPickerColumns"
-                                :state-path="$statePath"
+                                :key="$key"
                                 :width="$blockPickerWidth"
                                 class="flex justify-center"
                             >
@@ -269,10 +294,10 @@
                         @endif
                     </div>
                 </div>
-                @if(config('filament-page-builder.enablePreview'))
+
+                @if ($previewEnabled)
                     <div class="basis-2/3 p-4 mt-[1rem] overflow-y-auto flex flex-col items-center gap-4" x-show="showModal" x-data="{ breakpoint: 'max-w-full' }">
-                        <div class="fixed top-8 right-8 text-black/80 cursor-pointer" x-on:click="showModal = false"
-                             title="close">
+                        <div class="fixed top-8 right-8 text-black/80 cursor-pointer" x-on:click="showModal = false" title="close">
                             <x-filament::icon-button
                                 color="gray"
                                 icon="heroicon-o-x-mark"
@@ -283,33 +308,30 @@
                                 class="fi-modal-close-btn -m-1.5"
                             />
                         </div>
-    {{--                    todo breakpoints not working, disabled for now--}}
-    {{--                    <div class="flex flex-row gap-2">--}}
-    {{--                        <x-filament::button x-on:click="breakpoint = 'max-w-sm'">Mobile</x-filament::button>--}}
-    {{--                        <x-filament::button x-on:click="breakpoint = 'max-w-3xl'">Tablet</x-filament::button>--}}
-    {{--                        <x-filament::button x-on:click="breakpoint = 'max-w-full'">Desktop</x-filament::button>--}}
-    {{--                    </div>--}}
-                        @if($containers)
-                        <div x-bind:class="breakpoint"
-                             class="w-full bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10 transition-all">
-                            @foreach ($containers as $uuid => $item)
-                                <user-card>
-                                    {!! $preview($item) !!}
-                                </user-card>
-                            @endforeach
-                        </div>
+
+                        @if ($items)
+                            <div x-bind:class="breakpoint" class="w-full bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-white/5 dark:ring-white/10 transition-all">
+                                @foreach ($items as $itemKey => $item)
+                                    <user-card>
+                                        {!! $preview($item) !!}
+                                    </user-card>
+                                @endforeach
+                            </div>
                         @endif
                     </div>
                 @endif
             </div>
         </div>
     </div>
+
     <script type="application/javascript" wire:ignore>
-        customElements.define('user-card', class extends HTMLElement {
-            connectedCallback() {
-                this.attachShadow({mode: 'open'});
-                this.shadowRoot.innerHTML = `<slot></slot>`;
-            }
-        });
+        if (! customElements.get('user-card')) {
+            customElements.define('user-card', class extends HTMLElement {
+                connectedCallback() {
+                    this.attachShadow({ mode: 'open' });
+                    this.shadowRoot.innerHTML = `<slot></slot>`;
+                }
+            });
+        }
     </script>
 </x-dynamic-component>

--- a/src/BlockRenderer.php
+++ b/src/BlockRenderer.php
@@ -14,9 +14,7 @@ class BlockRenderer
 {
     private ?array $cache = null;
 
-    public function __construct(protected Filesystem $filesystem)
-    {
-    }
+    public function __construct(protected Filesystem $filesystem) {}
 
     /**
      * @return class-string<BlockEditorBlock>[]
@@ -46,8 +44,8 @@ class BlockRenderer
                         ->replace(['/'], ['\\']),
                 ) : null;
 
-                if (is_string($variableNamespace)) {
-                    $variableNamespace = (string) Str::of($variableNamespace)->before('\\');
+                if ($variableNamespace !== null) {
+                    $variableNamespace = (string) Str::of((string) $variableNamespace)->before('\\');
                 }
 
                 return (string) $namespace
@@ -69,7 +67,7 @@ class BlockRenderer
         /* @var class-string<BlockEditorBlock> $class */
         if ($class = ($this->getAllBlocks()[$block->type] ?? false)) {
             $pageContent = $block->content;
-            //todo dirty hack to 'detect' if translations are in use ...
+            // todo dirty hack to 'detect' if translations are in use ...
             if ($block->content === '') {
                 $pageContent = $block->translations['content'];
             }

--- a/src/BlockRenderer.php
+++ b/src/BlockRenderer.php
@@ -33,7 +33,8 @@ class BlockRenderer
             return [];
         }
 
-        $namespace = Str::of(Filament::getCurrentPanel()->getResourceNamespaces()[0])->beforeLast('\\')->append('\\Blocks*');
+        $panel = Filament::getCurrentPanel() ?? Filament::getDefaultPanel();
+        $namespace = Str::of($panel->getResourceNamespaces()[0])->beforeLast('\\')->append('\\Blocks*');
 
         $classes = collect($this->filesystem->allFiles($blocksDirectory))
             ->map(function (SplFileInfo $file) use ($namespace) {

--- a/src/Blocks/BlockEditorBlock.php
+++ b/src/Blocks/BlockEditorBlock.php
@@ -26,13 +26,13 @@ abstract class BlockEditorBlock extends Block
 
     abstract public function renderDisplay(array $state): string|View;
 
-    public function getChildComponents(): array
+    public function getDefaultChildComponents(): array
     {
         $formFields = $this->form();
         if (config('filament-page-builder.enablePreview')) {
             /** @var Field $field */
             foreach ($formFields as $field) {
-                $field->debounce()->reactive();
+                $field->live(debounce: 500);
             }
         }
 

--- a/src/Commands/MakePageBuilderBlock.php
+++ b/src/Commands/MakePageBuilderBlock.php
@@ -69,7 +69,7 @@ class MakePageBuilderBlock extends GeneratorCommand
     /**
      * Write the view for the component.
      */
-    protected function writeView(Closure $onSuccess = null): void
+    protected function writeView(?Closure $onSuccess = null): void
     {
         $path = $this->viewPath(
             str_replace('.', '/', 'filament.blocks.'.$this->getView()).'.blade.php'

--- a/src/Forms/Components/BlockEditor.php
+++ b/src/Forms/Components/BlockEditor.php
@@ -4,16 +4,16 @@ namespace Sevendays\FilamentPageBuilder\Forms\Components;
 
 use Closure;
 use ErrorException;
-use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\Builder;
-use Filament\Forms\Contracts\HasForms;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Livewire\Component;
 use Sevendays\FilamentPageBuilder\Blocks\BlockEditorBlock;
 use Sevendays\FilamentPageBuilder\Models\Block;
 
@@ -43,17 +43,16 @@ class BlockEditor extends Builder
 
     private array $coreFields = ['id', 'type', 'position'];
 
-    public function configure(): static
+    protected function setUp(): void
     {
-        parent::configure();
-        $this->relationship('blocks');
+        parent::setUp();
 
-        return $this;
+        $this->relationship('blocks');
     }
 
-    public function blocks(Closure|array $blocks): static
+    public function blocks(array|Closure $blocks): static
     {
-        if ($blocks instanceof \Closure) {
+        if ($blocks instanceof Closure) {
             throw new \Exception('Not supported yet.');
         }
 
@@ -72,42 +71,42 @@ class BlockEditor extends Builder
         return $this;
     }
 
-    public function getChildComponentContainers(bool $withHidden = false): array
+    /**
+     * @return array<Schema>
+     */
+    public function getItems(): array
     {
         $relationship = $this->getRelationship();
 
         $records = $relationship ? $this->getCachedExistingRecords() : null;
 
-        $container = collect($this->getState())
-            ->filter(fn (array $itemData): bool => $this->hasBlock($itemData['type']))
+        return collect($this->getRawState() ?? [])
+            ->filter(fn ($itemData): bool => is_array($itemData) && filled($itemData['type'] ?? null) && $this->hasBlock($itemData['type']))
             ->map(
-                fn (array $itemData, $itemIndex): ComponentContainer => $this
+                fn (array $itemData, $itemIndex): Schema => $this
                     ->getBlock($itemData['type'])
-                    ->getChildComponentContainer()
+                    ->getChildSchema()
                     ->model($relationship ? $records[$itemIndex] ?? $this->getRelatedModel() : null)
                     ->statePath("{$itemIndex}.data")
+                    ->constantState($itemData['data'] ?? [])
                     ->inlineLabel(false)
                     ->getClone(),
             )
             ->all();
-
-        return $container;
     }
 
-    public function relationship(string|Closure $name = null, Closure $callback = null): static
+    public function relationship(string|Closure|null $name = null, ?Closure $callback = null): static
     {
         $this->relationship = $name ?? $this->getName();
         $this->modifyRelationshipQueryUsing = $callback;
 
-        $this->afterStateHydrated(null);
-
-        $this->loadStateFromRelationshipsUsing(static function (BlockEditor $component) {
+        $this->loadStateFromRelationshipsUsing(static function (BlockEditor $component): void {
             $component->clearCachedExistingRecords();
 
             $component->fillFromRelationship();
         });
 
-        $this->saveRelationshipsUsing(static function (BlockEditor $component, HasForms $livewire, ?array $state) {
+        $this->saveRelationshipsUsing(static function (BlockEditor $component, HasSchemas $livewire, ?array $state): void {
             if (! is_array($state)) {
                 $state = [];
             }
@@ -127,21 +126,19 @@ class BlockEditor extends Builder
             }
 
             $relationship
-                //todo check if we can use same way as in Repeater
-                //->whereIn($relationship->getRelated()->getQualifiedKeyName(), $recordsToDelete)
                 ->whereKey($recordsToDelete)
                 ->get()
                 ->each(static fn (Model $record) => $record->delete());
 
-            $childComponentContainers = $component->getChildComponentContainers();
+            $childSchemas = $component->getItems();
 
             $itemOrder = 1;
             $orderColumn = $component->getOrderColumn();
 
-            $activeLocale = $livewire->getActiveFormsLocale();
+            $activeLocale = $livewire->getActiveSchemaLocale();
             $translatableContentDriver = $livewire->makeFilamentTranslatableContentDriver();
 
-            foreach ($childComponentContainers as $itemKey => $item) {
+            foreach ($childSchemas as $itemKey => $item) {
                 $itemData = $item->getState(shouldCallHooksBefore: false);
 
                 if ($orderColumn) {
@@ -150,10 +147,10 @@ class BlockEditor extends Builder
                     $itemOrder++;
                 }
 
-                /** @var Model $record */
-                if ($record = ($existingRecords[$itemKey] ?? null)) {
-                    //$activeLocale && method_exists($record, 'setLocale') && $record->setLocale($activeLocale);
+                /** @var Model|null $record */
+                $record = $existingRecords[$itemKey] ?? null;
 
+                if ($record) {
                     $itemData = $component->mutateRelationshipDataBeforeSave($itemData, record: $record);
 
                     $translatableContentDriver ?
@@ -161,21 +158,6 @@ class BlockEditor extends Builder
                         $record->fill($itemData)->save();
 
                     continue;
-
-                    //                    if ($activeLocale && $record instanceof Block) {
-                    //                        // Handle locale saving.
-                    //                        $record->fill(Arr::except($itemData, $record->getTranslatableAttributes()));
-                    //
-                    //                        foreach (Arr::only($itemData, $record->getTranslatableAttributes()) as $key => $value) {
-                    //                            $record->setTranslation($key, $activeLocale, $value);
-                    //                        }
-                    //
-                    //                        $record->save();
-                    //                    } else {
-                    //                        $record->fill($itemData)->save();
-                    //                    }
-                    //
-                    //                    continue;
                 }
 
                 $relatedModel = $component->getRelatedModel();
@@ -186,16 +168,14 @@ class BlockEditor extends Builder
                     $record->setLocale($activeLocale);
                 }
 
-                /** @var ComponentContainer $item */
                 $itemData = $component->mutateRelationshipDataBeforeCreate($itemData, $item->getParentComponent());
 
                 if ($activeLocale && $record instanceof Block) {
-                    // Handle locale saving.
                     $record->fill(Arr::except($itemData, $record->getTranslatableAttributes()));
+
                     foreach (Arr::only($itemData, $record->getTranslatableAttributes()) as $key => $value) {
                         $record->setTranslation($key, $activeLocale, $value);
                     }
-
                 } else {
                     $record->fill($itemData);
                 }
@@ -280,7 +260,7 @@ class BlockEditor extends Builder
 
         $translatableContentDriver = $this->getLivewire()->makeFilamentTranslatableContentDriver();
 
-        $state = $records
+        return $records
             ->map(function (Model $record) use ($translatableContentDriver): array {
                 $data = $translatableContentDriver ?
                     $translatableContentDriver->getRecordAttributesToArray($record) :
@@ -289,8 +269,6 @@ class BlockEditor extends Builder
                 return $this->mutateRelationshipDataBeforeFill($data);
             })
             ->toArray();
-
-        return $state;
     }
 
     public function mutateRelationshipDataBeforeCreate(array $data, Component|null|BlockEditorBlock $item): array
@@ -321,6 +299,7 @@ class BlockEditor extends Builder
                 'record' => $record,
             ]);
         }
+
         /* @var string $type */
         $type = $record['type'];
         $data['type'] = $type;
@@ -354,7 +333,7 @@ class BlockEditor extends Builder
             ]);
         }
 
-        if (is_array($data['content'])) {
+        if (is_array($data['content'] ?? null)) {
             foreach ($data['content'] as $field => $value) {
                 if (! in_array($field, $this->coreFields, true)) {
                     $data['data'][$field] = $value;
@@ -384,7 +363,7 @@ class BlockEditor extends Builder
         return $this;
     }
 
-    public function preview(ComponentContainer $container): View|string
+    public function preview(Schema $container): View|string
     {
         if (! $view = $this->evaluate($this->renderInView)) {
             return __('renderInView not set or null');
@@ -399,7 +378,7 @@ class BlockEditor extends Builder
 
             return view(
                 $view,
-                ['preview' => $container->getParentComponent()->renderDisplay($state)]            /* @phpstan-ignore-line */
+                ['preview' => $container->getParentComponent()->renderDisplay($state)] /* @phpstan-ignore-line */
             );
         } catch (ErrorException|\Exception $e) {
             return __('Error when rendering: :phError', ['phError' => $e->getMessage()]);

--- a/src/Forms/Components/BlockEditor.php
+++ b/src/Forms/Components/BlockEditor.php
@@ -5,20 +5,20 @@ namespace Sevendays\FilamentPageBuilder\Forms\Components;
 use Closure;
 use ErrorException;
 use Filament\Forms\Components\Builder;
-use Filament\Schemas\Components\Component;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
 use Sevendays\FilamentPageBuilder\Blocks\BlockEditorBlock;
 use Sevendays\FilamentPageBuilder\Models\Block;
 
 class BlockEditor extends Builder
 {
+    /** @phpstan-ignore property.defaultValue */
     protected string $view = 'filament-page-builder::block-editor';
 
     protected bool|Closure|null $isCollapsible = true;
@@ -135,7 +135,6 @@ class BlockEditor extends Builder
             $itemOrder = 1;
             $orderColumn = $component->getOrderColumn();
 
-            $activeLocale = $livewire->getActiveSchemaLocale();
             $translatableContentDriver = $livewire->makeFilamentTranslatableContentDriver();
 
             foreach ($childSchemas as $itemKey => $item) {
@@ -162,21 +161,14 @@ class BlockEditor extends Builder
 
                 $relatedModel = $component->getRelatedModel();
 
-                $record = new $relatedModel();
+                /** @var BlockEditorBlock $parent */
+                $parent = $item->getParentComponent();
+                $itemData = $component->mutateRelationshipDataBeforeCreate($itemData, $parent);
 
-                if ($activeLocale && method_exists($record, 'setLocale')) {
-                    $record->setLocale($activeLocale);
-                }
-
-                $itemData = $component->mutateRelationshipDataBeforeCreate($itemData, $item->getParentComponent());
-
-                if ($activeLocale && $record instanceof Block) {
-                    $record->fill(Arr::except($itemData, $record->getTranslatableAttributes()));
-
-                    foreach (Arr::only($itemData, $record->getTranslatableAttributes()) as $key => $value) {
-                        $record->setTranslation($key, $activeLocale, $value);
-                    }
+                if ($translatableContentDriver) {
+                    $record = $translatableContentDriver->makeRecord($relatedModel, $itemData);
                 } else {
+                    $record = new $relatedModel;
                     $record->fill($itemData);
                 }
 
@@ -271,7 +263,7 @@ class BlockEditor extends Builder
             ->toArray();
     }
 
-    public function mutateRelationshipDataBeforeCreate(array $data, Component|null|BlockEditorBlock $item): array
+    public function mutateRelationshipDataBeforeCreate(array $data, BlockEditorBlock $item): array
     {
         if ($this->mutateRelationshipDataBeforeCreateUsing instanceof Closure) {
             $data = $this->evaluate($this->mutateRelationshipDataBeforeCreateUsing, [
@@ -373,7 +365,7 @@ class BlockEditor extends Builder
             $state = [];
             try {
                 $state = $container->getState(false);
-            } catch (\Illuminate\Validation\ValidationException $e) {
+            } catch (ValidationException $e) {
             }
 
             return view(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,11 +11,12 @@ use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
 use Filament\Infolists\InfolistsServiceProvider;
 use Filament\Notifications\NotificationsServiceProvider;
-use Filament\SpatieLaravelTranslatablePluginServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use LaraZeus\SpatieTranslatable\SpatieLaravelTranslatablePluginServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
@@ -44,6 +45,7 @@ class TestCase extends Orchestra
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
             NotificationsServiceProvider::class,
+            SchemasServiceProvider::class,
             SpatieLaravelTranslatablePluginServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,


### PR DESCRIPTION
Port BlockEditor, BlockEditorBlock and the block-editor.blade view to Filament v4's Schemas API. Key changes:

- composer: bump filament/filament to ^4.0, replace the deprecated filament/spatie-laravel-translatable-plugin with lara-zeus/spatie- translatable, drop wire-elements/modal (unused), raise Laravel floor to ^11.28/^12.0 to match Filament v4.
- BlockEditor now extends v4's Filament\Forms\Components\Builder and overrides getItems() instead of the v3 getChildComponentContainers(). ComponentContainer references become Filament\Schemas\Schema. HasForms -> Filament\Schemas\Contracts\HasSchemas and getActiveFormsLocale() -> getActiveSchemaLocale() in the save path. The custom ->relationship() logic is kept because v4's Builder (unlike Repeater) still has no built-in relationship() — we mirror what Repeater does to keep existing consumers working unchanged.
- BlockEditorBlock overrides getDefaultChildComponents() instead of getChildComponents(); v4's base signature accepts a ?string $key so the old override now collides with it. The preview-mode debounce switches from reactive()/debounce() to live(debounce: 500).
- BlockRenderer falls back to Filament::getDefaultPanel() on the frontend where getCurrentPanel() returns null.
- The block-editor blade is rewritten against v4's builder structure: $getItems() replaces $getChildComponentContainers, fi-fo-builder-* CSS classes, $item->getLivewireKey() for wire:key, 3-arg Block::getLabel and x-on:end.stop dispatch to $wire.mountAction('reorder', ..., { schemaComponent: $key }). The preview-modal and visual builder opt-in are preserved.

Also bumps dev-deps to Pest 3 / PHPUnit 11 / Larastan 3 / Orchestra 9-10, updates the TestCase to pull in Filament\Schemas\SchemasServiceProvider and the Lara Zeus translatable provider, and fixes a PHP 8.4 implicitly nullable parameter in MakePageBuilderBlock::writeView.

This release drops v3 support; consumers need Filament ^4.0. Tailwind v4.1+ is required if the consumer ships a custom theme.